### PR TITLE
Provide safe defaults for Settings configuration

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -5,20 +5,46 @@ from functools import lru_cache
 from typing import Literal
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Central settings object loaded from environment variables."""
 
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="allow")
+
     app_name: str = "Zoris API"
     environment: Literal["local", "staging", "production"] = "local"
-    database_url: str = Field(..., alias="DATABASE_URL")
-    redis_url: str = Field(..., alias="REDIS_URL")
-    s3_endpoint: str = Field(..., alias="S3_ENDPOINT")
-    s3_access_key: str = Field(..., alias="S3_ACCESS_KEY")
-    s3_secret_key: str = Field(..., alias="S3_SECRET_KEY")
-    s3_bucket: str = Field(..., alias="S3_BUCKET")
+    database_url: str = Field(
+        default="sqlite+aiosqlite:///./zoris.db",
+        alias="DATABASE_URL",
+        description="SQLAlchemy connection string for the primary database.",
+    )
+    redis_url: str = Field(
+        default="redis://localhost:6379/0",
+        alias="REDIS_URL",
+        description="Redis connection string for Celery broker/backend.",
+    )
+    s3_endpoint: str = Field(
+        default="http://localhost:9000",
+        alias="S3_ENDPOINT",
+        description="Endpoint for the S3-compatible object store.",
+    )
+    s3_access_key: str = Field(
+        default="minio",
+        alias="S3_ACCESS_KEY",
+        description="Access key for the S3-compatible object store.",
+    )
+    s3_secret_key: str = Field(
+        default="miniosecret",
+        alias="S3_SECRET_KEY",
+        description="Secret key for the S3-compatible object store.",
+    )
+    s3_bucket: str = Field(
+        default="zoris-local",
+        alias="S3_BUCKET",
+        description="Bucket used for storing uploaded assets.",
+    )
     ocr_provider: Literal["tesseract", "textract"] = Field(
         default="tesseract", alias="OCR_PROVIDER"
     )
@@ -28,12 +54,6 @@ class Settings(BaseSettings):
     qbo_enabled: bool = Field(default=False, alias="QBO_ENABLED")
     station_pin_rotate_minutes: int = Field(default=1440, alias="STATION_PIN_ROTATE_MINUTES")
     feature_auto_approve_ocr: bool = Field(default=True, alias="AUTO_APPROVE_OCR")
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        extra = "allow"
-
 
 @lru_cache(1)
 def get_settings() -> Settings:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 sqlalchemy[asyncio]
 asyncpg
+aiosqlite
 alembic
 pydantic-settings
 celery


### PR DESCRIPTION
## Summary
- configure the Pydantic settings model with SettingsConfigDict for env loading
- supply local-friendly defaults for required service URLs and credentials
- include aiosqlite so the SQLite default connection string works out of the box

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e40aa7ae188331b93e70f749cab5d0