### PR TITLE
Fix build by updating shadcn ui dependency

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -19,7 +19,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.5",
     "@clerk/nextjs": "^4.29.1",
-    "@shadcn/ui": "^0.8.0"
+    "@shadcn/ui": "^0.9.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",


### PR DESCRIPTION
## Summary
- update the @shadcn/ui dependency to ^0.9.0 so that npm can resolve the package during builds

## Testing
- npm install *(fails: 403 Forbidden to npm registry in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4152bac588331b9602ed6d4267332