### PR TITLE
Support Redis environment aliases for Celery

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     )
     redis_url: str = Field(
         default="redis://localhost:6379/0",
-        alias="REDIS_URL",
+        validation_alias=AliasChoices("REDIS_URL", "REDIS_TLS_URL"),
         description="Redis connection string for Celery broker/backend.",
     )
     s3_endpoint: str = Field(


### PR DESCRIPTION
## Summary
- allow the API settings to read Redis configuration from REDIS_URL or REDIS_TLS_URL
- keep the existing localhost default for local development

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e4174fd1288331bc95fa794aa0d351