### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ boto3
 pytesseract
 pillow
 httpx
+python-multipart
 python-dotenv
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Summary
- add the python-multipart package to the application requirements so FastAPI form handling works

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e417b085ec8331be2c22b61cebc7d6