### PR TITLE
Fix invalid JSON formatting in web package manifest

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -18,19 +18,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.5",
-    "@clerk/nextjs": "^4.29.1",
+    "@clerk/nextjs": "^4.31.8",
     "@shadcn/ui": "^0.9.0"
-
-    "@clerk/nextjs": "^4.31.8"
-
-
-    "@clerk/nextjs": "^4.29.1"
-
-    "@clerk/nextjs": "^4.29.1",
-    "@shadcn/ui": "^0.9.0"
-
-
-
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",


### PR DESCRIPTION
## Summary
- remove duplicate dependency entries in `app/web/package.json`
- ensure the manifest is valid JSON so install/build steps can parse it

## Testing
- node -e "const pkg=require('./package.json'); console.log(Object.keys(pkg.dependencies));" (from app/web)


------
https://chatgpt.com/codex/tasks/task_e_68e41b90aa7083318274527016115d5b