### PR TITLE
Remove unavailable @shadcn/ui dependency

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -18,8 +18,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.5",
-    "@clerk/nextjs": "^4.31.8",
-    "@shadcn/ui": "^0.9.0"
+    "@clerk/nextjs": "^4.31.8"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.1",


### PR DESCRIPTION
## Summary
- remove the @shadcn/ui dependency from the web package since the referenced version does not exist in the npm registry

## Testing
- npm install *(fails: registry returned 403 for @clerk/nextjs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41d814dc88331bd5989f534eed5fb