### PR TITLE
Fail fast when Redis is not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ variable sets:
 - Or provide discrete parts such as `REDIS_HOST`, `REDIS_PORT`,
   `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_DB`, and `REDIS_USE_TLS=true`.
 
-If neither option is present the application falls back to the local
-`redis://localhost:6379/0` URL, which will result in `Connection refused`
-messages on managed hosting providers.
+If neither option is present and `ENVIRONMENT` is set to `local`, the
+application falls back to the local `redis://localhost:6379/0` URL for the
+Docker Compose stack. In all other environments the application now fails fast
+with a clear configuration error so that you can supply the appropriate Redis
+endpoint instead of getting repeated `Connection refused` messages during
+deployments.

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -105,8 +105,14 @@ class Settings(BaseSettings):
             self.redis_url = f"{scheme}://{auth}{self.redis_host}:{port}/{self.redis_db}"
             return self
 
-        self.redis_url = f"redis://localhost:6379/{self.redis_db}"
-        return self
+        if self.environment == "local":
+            self.redis_url = f"redis://localhost:6379/{self.redis_db}"
+            return self
+
+        raise ValueError(
+            "Redis connection details are required when environment!='local'. "
+            "Set REDIS_URL/REDIS_TLS_URL or the discrete REDIS_* variables."
+        )
 
 @lru_cache(1)
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary
- require explicit Redis configuration when running outside the local environment
- document the new behavior so deploys provide actionable feedback

## Testing
- pytest *(fails: app/api/tests import assumptions)*

------
https://chatgpt.com/codex/tasks/task_e_68e54f942c1c8331addbd9992fec1d34