### PR TITLE
Require explicit Redis configuration for Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ variable sets:
 - Or provide discrete parts such as `REDIS_HOST`, `REDIS_PORT`,
   `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_DB`, and `REDIS_USE_TLS=true`.
 
-If neither option is present and `ENVIRONMENT` is set to `local`, the
-application falls back to the local `redis://localhost:6379/0` URL for the
-Docker Compose stack. In all other environments the application now fails fast
-with a clear configuration error so that you can supply the appropriate Redis
-endpoint instead of getting repeated `Connection refused` messages during
-deployments.
+If neither option is present the application now fails fast with a clear
+configuration error so that you can supply the appropriate Redis endpoint
+instead of getting repeated `Connection refused` messages during deployments.

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -105,13 +105,9 @@ class Settings(BaseSettings):
             self.redis_url = f"{scheme}://{auth}{self.redis_host}:{port}/{self.redis_db}"
             return self
 
-        if self.environment == "local":
-            self.redis_url = f"redis://localhost:6379/{self.redis_db}"
-            return self
-
         raise ValueError(
-            "Redis connection details are required when environment!='local'. "
-            "Set REDIS_URL/REDIS_TLS_URL or the discrete REDIS_* variables."
+            "Redis connection details are required. Set REDIS_URL/REDIS_TLS_URL "
+            "or the discrete REDIS_* variables so Celery can reach Redis."
         )
 
 @lru_cache(1)


### PR DESCRIPTION
## Summary
- remove the implicit localhost Redis fallback so Celery requires an explicit configuration
- update the README to explain the new behavior and avoid silent connection-refused loops

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e556927f2083318f6f6223e078310b