### PR TITLE
Ensure inventory adjustments use Decimal arithmetic

### DIFF
--- a/app/api/routes/inventory.py
+++ b/app/api/routes/inventory.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
@@ -26,12 +27,15 @@ async def adjust_inventory(payload: InventoryAdjustRequest, session: AsyncSessio
         inventory = Inventory(
             item_id=payload.item_id,
             location_id=payload.location_id,
-            qty_on_hand=0,
-            qty_reserved=0,
-            avg_cost=0,
+            qty_on_hand=Decimal("0"),
+            qty_reserved=Decimal("0"),
+            avg_cost=Decimal("0"),
         )
         session.add(inventory)
-    inventory.qty_on_hand = (inventory.qty_on_hand or 0) + payload.qty_delta
+
+    current_qty = inventory.qty_on_hand if inventory.qty_on_hand is not None else Decimal("0")
+    qty_delta = Decimal(str(payload.qty_delta))
+    inventory.qty_on_hand = Decimal(current_qty) + qty_delta
     txn = InventoryTxn(
         item_id=payload.item_id,
         location_id=payload.location_id,

--- a/app/api/tests/__init__.py
+++ b/app/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for API application."""

--- a/app/api/tests/conftest.py
+++ b/app/api/tests/conftest.py
@@ -4,8 +4,9 @@ import asyncio
 from collections.abc import AsyncIterator
 
 import pytest
+import pytest_asyncio
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import Settings
@@ -20,7 +21,8 @@ def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
     loop.close()
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def client() -> AsyncIterator[AsyncClient]:
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client

--- a/app/api/tests/test_inventory.py
+++ b/app/api/tests/test_inventory.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from ..db import SessionLocal, engine
+from ..models.base import Base
+from ..models.domain import Inventory, Item, Location
+from ..routes.inventory import adjust_inventory
+from ..schemas.common import InventoryAdjustRequest
+
+
+@pytest.mark.asyncio
+async def test_adjust_inventory_preserves_decimal_storage():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with SessionLocal() as session:
+        item = Item(
+            sku="SKU-DECIMAL",
+            description="Decimal Item",
+            unit_cost=Decimal("1.00"),
+            price=Decimal("2.00"),
+            short_code="D001",
+        )
+        location = Location(name="Warehouse", type="warehouse")
+        inventory = Inventory(
+            item=item,
+            location=location,
+            qty_on_hand=Decimal("5.50"),
+            qty_reserved=Decimal("0.00"),
+            avg_cost=Decimal("1.00"),
+        )
+        session.add_all([item, location, inventory])
+        await session.commit()
+        await session.refresh(item)
+        await session.refresh(location)
+        await session.refresh(inventory)
+        item_id = item.item_id
+        location_id = location.location_id
+        inventory_id = inventory.inv_id
+
+    payload = InventoryAdjustRequest(
+        item_id=item_id,
+        location_id=location_id,
+        qty_delta=2.5,
+        reason="adjust",
+    )
+
+    async with SessionLocal() as session:
+        response = await adjust_inventory(payload, session=session)
+        await session.commit()
+
+    assert response["new_qty"] == pytest.approx(8.0)
+
+    async with SessionLocal() as session:
+        updated_inventory = await session.scalar(
+            select(Inventory).where(Inventory.inv_id == inventory_id)
+        )
+        assert updated_inventory is not None
+        assert isinstance(updated_inventory.qty_on_hand, Decimal)
+        assert updated_inventory.qty_on_hand == Decimal("8.00")

--- a/app/api/tests/test_zapier.py
+++ b/app/api/tests/test_zapier.py
@@ -14,7 +14,7 @@ async def test_post_with_retry(monkeypatch):
             if len(attempts) < 2:
                 raise RuntimeError("boom")
 
-    async def fake_post(url, json, timeout):  # noqa: A002 - shadowing json arg is intentional
+    async def fake_post(self, url, **kwargs):
         attempts.append(1)
         if len(attempts) < 3:
             raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- coerce inventory adjustments to use Decimal math before persisting and keep API responses JSON-friendly
- modernize async test client fixture for current httpx/pytest-asyncio behavior
- add regression coverage for Decimal inventory adjustments and update Zapier retry test helper

## Testing
- REDIS_URL=redis://localhost:6379/0 pytest app/api/tests

------
https://chatgpt.com/codex/tasks/task_e_68e5823d81248331a56b7e0412bdb276