### PR TITLE
Add delivery status API and driver UI integration

### DIFF
--- a/app/api/schemas/common.py
+++ b/app/api/schemas/common.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -64,6 +64,21 @@ class SaleFinalizeResponse(BaseModel):
 class SaleDeliveryRequest(BaseModel):
     delivery_requested: bool
     address: dict | None = None
+
+
+class SaleDeliveryStatusUpdate(BaseModel):
+    delivery_status: Literal[
+        "queued",
+        "scheduled",
+        "out_for_delivery",
+        "delivered",
+        "failed",
+    ]
+
+
+class SaleDeliveryStatusResponse(BaseModel):
+    sale_id: int
+    delivery_status: str | None
 
 
 class OCRSaleTicketResponse(BaseModel):

--- a/app/api/services/zapier.py
+++ b/app/api/services/zapier.py
@@ -31,3 +31,9 @@ def ticket_finalized(payload: dict[str, Any]) -> None:
     if not settings.zap_ticket_finalized_url:
         return
     asyncio.create_task(post_with_retry(settings.zap_ticket_finalized_url, payload))
+
+
+def delivery_completed(payload: dict[str, Any]) -> None:
+    if not settings.zap_delivery_completed_url:
+        return
+    asyncio.create_task(post_with_retry(settings.zap_delivery_completed_url, payload))

--- a/app/web/app/delivery/[id]/page.tsx
+++ b/app/web/app/delivery/[id]/page.tsx
@@ -1,34 +1,146 @@
 'use client';
 
+import axios from 'axios';
 import { useParams } from 'next/navigation';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type DeliveryStatus =
+  | 'queued'
+  | 'scheduled'
+  | 'out_for_delivery'
+  | 'delivered'
+  | 'failed';
+
+const statusLabels: Record<DeliveryStatus, string> = {
+  queued: 'Queued',
+  scheduled: 'Scheduled',
+  out_for_delivery: 'Out for delivery',
+  delivered: 'Delivered',
+  failed: 'Attention required'
+};
+
+const statusClasses: Record<DeliveryStatus, string> = {
+  queued: 'border-amber-400/60 bg-amber-500/20 text-amber-100',
+  scheduled: 'border-sky-400/60 bg-sky-500/20 text-sky-100',
+  out_for_delivery: 'border-indigo-400/60 bg-indigo-500/20 text-indigo-100',
+  delivered: 'border-emerald-400/60 bg-emerald-500/20 text-emerald-100',
+  failed: 'border-rose-400/60 bg-rose-500/20 text-rose-100'
+};
+
+interface DeliveryStatusResponse {
+  sale_id: number;
+  delivery_status: DeliveryStatus | null;
+}
 
 export default function DeliveryPage() {
   const { id } = useParams<{ id: string }>();
-  const [status, setStatus] = useState<string>('queued');
+  const api = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-  const actions: { label: string; next: string }[] = [
-    { label: 'Arrived', next: 'scheduled' },
-    { label: 'Delivered', next: 'delivered' },
-    { label: 'Problem', next: 'failed' }
+  const [status, setStatus] = useState<DeliveryStatus | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [updating, setUpdating] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const badgeClass = useMemo(() => {
+    const base = 'inline-flex items-center rounded-full border px-4 py-1 text-sm font-semibold uppercase tracking-wide';
+    if (!status) {
+      return `${base} border-slate-400/60 bg-slate-800 text-slate-200`;
+    }
+    return `${base} ${statusClasses[status]}`;
+  }, [status]);
+
+  const friendlyStatus = status ? statusLabels[status] : loading ? 'Loading…' : 'Unknown';
+
+  useEffect(() => {
+    let ignore = false;
+    const fetchStatus = async () => {
+      if (!id) {
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const { data } = await axios.get<DeliveryStatusResponse>(
+          `${api}/sales/${id}/delivery-status`
+        );
+        if (!ignore) {
+          setStatus(data.delivery_status ?? 'queued');
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError('Unable to load delivery status.');
+          setStatus(null);
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchStatus();
+
+    return () => {
+      ignore = true;
+    };
+  }, [api, id]);
+
+  const handleUpdate = useCallback(
+    async (next: DeliveryStatus) => {
+      if (!id) {
+        return;
+      }
+      setUpdating(true);
+      setError(null);
+      try {
+        const { data } = await axios.patch<DeliveryStatusResponse>(
+          `${api}/sales/${id}/delivery-status`,
+          { delivery_status: next }
+        );
+        setStatus(data.delivery_status ?? next);
+      } catch (err) {
+        setError('Unable to update delivery status.');
+      } finally {
+        setUpdating(false);
+      }
+    },
+    [api, id]
+  );
+
+  const actions: { label: string; next: DeliveryStatus; tone: 'primary' | 'danger' }[] = [
+    { label: 'Scheduled', next: 'scheduled', tone: 'primary' },
+    { label: 'Out for Delivery', next: 'out_for_delivery', tone: 'primary' },
+    { label: 'Delivered', next: 'delivered', tone: 'primary' },
+    { label: 'Problem', next: 'failed', tone: 'danger' }
   ];
 
   return (
-    <main className="flex min-h-screen flex-col gap-4 bg-slate-900 p-8 text-white">
-      <h1 className="text-3xl font-bold">Delivery #{id}</h1>
-      <p className="text-slate-300">Current status: {status}</p>
-      <div className="grid gap-4 sm:grid-cols-3">
+    <main className="flex min-h-screen flex-col gap-6 bg-slate-900 p-8 text-white">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold">Delivery #{id}</h1>
+        <div className="flex items-center gap-3 text-slate-300">
+          <span>Current status</span>
+          <span className={badgeClass}>{friendlyStatus}</span>
+        </div>
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+      </header>
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {actions.map((action) => (
           <button
             key={action.label}
             type="button"
-            className="rounded bg-emerald-600 px-4 py-6 text-xl font-semibold shadow hover:bg-emerald-500"
-            onClick={() => setStatus(action.next)}
+            disabled={updating || loading}
+            className={`rounded px-4 py-6 text-lg font-semibold shadow transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 ${
+              action.tone === 'danger'
+                ? 'bg-rose-600 hover:bg-rose-500 focus:ring-rose-300 disabled:bg-rose-800/60'
+                : 'bg-emerald-600 hover:bg-emerald-500 focus:ring-emerald-300 disabled:bg-emerald-800/60'
+            }`}
+            onClick={() => handleUpdate(action.next)}
           >
             {action.label}
           </button>
         ))}
-      </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add delivery status schemas and endpoints for sales, guarded for drivers and admins and notifying Zapier when a delivery is completed
- include persisted delivery status in finalize payloads and when creating delivery requests
- enhance the delivery page to load the current status, call the API on button presses, and show badge styling and errors

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e582792a9c833191f46dc330938133