### PR TITLE
Add dashboard summary API and client integration

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,7 +1,7 @@
 """API routers."""
 from fastapi import APIRouter
 
-from . import health, config, items, inventory, sales, po, labels, ocr
+from . import config, dashboard, health, inventory, items, labels, ocr, po, sales
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -12,3 +12,4 @@ api_router.include_router(po.router, prefix="/po", tags=["po"])
 api_router.include_router(sales.router, prefix="/sales", tags=["sales"])
 api_router.include_router(labels.router, prefix="/labels", tags=["labels"])
 api_router.include_router(ocr.router, prefix="/ocr", tags=["ocr"])
+api_router.include_router(dashboard.router)

--- a/app/api/routes/dashboard.py
+++ b/app/api/routes/dashboard.py
@@ -1,0 +1,203 @@
+"""Dashboard summary endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..models.domain import PurchaseOrder, Receiving, Sale
+from ..schemas.dashboard import (
+    DashboardActivity,
+    DashboardMetric,
+    DashboardSummaryResponse,
+    DashboardSystemStatus,
+)
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+def _humanize_delta(now: datetime, past: datetime) -> str:
+    delta = now - past
+    seconds = int(delta.total_seconds())
+    if seconds < 60:
+        return "Just now"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = hours // 24
+    return f"{days} day{'s' if days != 1 else ''} ago"
+
+
+@router.get("/summary", response_model=DashboardSummaryResponse)
+async def get_dashboard_summary(
+    session: AsyncSession = Depends(get_session),
+) -> DashboardSummaryResponse:
+    now = datetime.utcnow()
+    last_24h = now - timedelta(hours=24)
+    worker_window = now - timedelta(hours=4)
+
+    open_sales_stmt = select(func.count()).select_from(Sale).where(Sale.status == "open")
+    open_sales = (await session.scalar(open_sales_stmt)) or 0
+    open_sales_today_stmt = (
+        select(func.count())
+        .select_from(Sale)
+        .where(Sale.status == "open", Sale.created_at >= last_24h)
+    )
+    open_sales_today = (await session.scalar(open_sales_today_stmt)) or 0
+
+    draft_ocr_stmt = (
+        select(func.count())
+        .select_from(Sale)
+        .where(Sale.status == "draft", Sale.source == "ocr_ticket")
+    )
+    draft_ocr = (await session.scalar(draft_ocr_stmt)) or 0
+    draft_ocr_new_stmt = (
+        select(func.count())
+        .select_from(Sale)
+        .where(
+            Sale.status == "draft",
+            Sale.source == "ocr_ticket",
+            Sale.created_at >= last_24h,
+        )
+    )
+    draft_ocr_new = (await session.scalar(draft_ocr_new_stmt)) or 0
+
+    inbound_stmt = (
+        select(func.count())
+        .select_from(PurchaseOrder)
+        .where(PurchaseOrder.status.in_(["open", "partial"]))
+    )
+    inbound = (await session.scalar(inbound_stmt)) or 0
+    recent_receivings_stmt = (
+        select(func.count())
+        .select_from(Receiving)
+        .where(Receiving.created_at >= last_24h)
+    )
+    recent_receivings = (await session.scalar(recent_receivings_stmt)) or 0
+
+    worker_activity_stmt = (
+        select(func.count(func.distinct(Receiving.received_by)))
+        .select_from(Receiving)
+        .where(Receiving.created_at >= worker_window)
+    )
+    active_workers = (await session.scalar(worker_activity_stmt)) or 0
+
+    metrics = [
+        DashboardMetric(
+            label="Open Sales",
+            value=open_sales,
+            change=f"{open_sales_today} created in last 24h",
+            status="awaiting fulfillment",
+        ),
+        DashboardMetric(
+            label="Draft OCR Tickets",
+            value=draft_ocr,
+            change=f"{draft_ocr_new} new in last 24h",
+            status="needs review",
+        ),
+        DashboardMetric(
+            label="Inbound Purchase Orders",
+            value=inbound,
+            change=f"{recent_receivings} receipts logged in last 24h",
+            status="receiving queue",
+        ),
+        DashboardMetric(
+            label="Active Receivers",
+            value=active_workers,
+            change=f"{recent_receivings} dock events in last 24h",
+            status="worker health",
+        ),
+    ]
+
+    activities: list[tuple[datetime, DashboardActivity]] = []
+    recent_sales = (
+        await session.execute(
+            select(Sale).order_by(Sale.created_at.desc()).limit(2)
+        )
+    ).scalars()
+    for sale in recent_sales:
+        activities.append(
+            (
+                sale.created_at,
+                DashboardActivity(
+                    title=f"Sale #{sale.sale_id} {sale.status}",
+                    description=f"Total ${float(sale.total or 0):,.2f}",
+                    time=_humanize_delta(now, sale.created_at),
+                ),
+            )
+        )
+
+    recent_receiving_rows = (
+        await session.execute(
+            select(Receiving).order_by(Receiving.created_at.desc()).limit(2)
+        )
+    ).scalars()
+    for receiving in recent_receiving_rows:
+        activities.append(
+            (
+                receiving.created_at,
+                DashboardActivity(
+                    title=f"PO #{receiving.po_id} received",
+                    description=f"Checked in by {receiving.received_by or 'Unknown associate'}",
+                    time=_humanize_delta(now, receiving.created_at),
+                ),
+            )
+        )
+
+    recent_pos = (
+        await session.execute(
+            select(PurchaseOrder).order_by(PurchaseOrder.created_at.desc()).limit(2)
+        )
+    ).scalars()
+    for po in recent_pos:
+        activities.append(
+            (
+                po.created_at,
+                DashboardActivity(
+                    title=f"PO #{po.po_id} {po.status}",
+                    description=f"Vendor #{po.vendor_id}",
+                    time=_humanize_delta(now, po.created_at),
+                ),
+            )
+        )
+
+    activities.sort(key=lambda item: item[0], reverse=True)
+    activity_payload = [item[1] for item in activities[:5]]
+
+    system_status = [
+        DashboardSystemStatus(
+            label="Worker Health",
+            state="Operational" if active_workers else "Idle",
+            badge="bg-emerald-500" if active_workers else "bg-amber-400",
+            description=(
+                f"{active_workers} associates checked in over last 4h"
+                if active_workers
+                else "No recent receiving scans."
+            ),
+        ),
+        DashboardSystemStatus(
+            label="OCR Pipeline",
+            state="Reviewing" if draft_ocr else "Clear",
+            badge="bg-sky-400" if draft_ocr else "bg-emerald-500",
+            description=f"{draft_ocr} tickets awaiting review.",
+        ),
+        DashboardSystemStatus(
+            label="Sales Pipeline",
+            state="Active" if open_sales else "Quiet",
+            badge="bg-indigo-400" if open_sales else "bg-slate-500",
+            description=f"{open_sales} open sales ready for fulfillment.",
+        ),
+    ]
+
+    return DashboardSummaryResponse(
+        metrics=metrics,
+        activity=activity_payload,
+        system_status=system_status,
+    )

--- a/app/api/schemas/dashboard.py
+++ b/app/api/schemas/dashboard.py
@@ -1,0 +1,30 @@
+"""Dashboard response models."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class DashboardMetric(BaseModel):
+    label: str
+    value: int
+    change: str
+    status: str
+
+
+class DashboardActivity(BaseModel):
+    title: str
+    description: str
+    time: str
+
+
+class DashboardSystemStatus(BaseModel):
+    label: str
+    state: str
+    badge: str
+    description: str
+
+
+class DashboardSummaryResponse(BaseModel):
+    metrics: list[DashboardMetric]
+    activity: list[DashboardActivity]
+    system_status: list[DashboardSystemStatus]

--- a/app/web/app/dashboard-summary-client.tsx
+++ b/app/web/app/dashboard-summary-client.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import useSWR from 'swr';
+
+import { apiBase } from '../lib/api';
+
+type DashboardMetric = {
+  label: string;
+  value: number;
+  change: string;
+  status: string;
+};
+
+type DashboardActivity = {
+  title: string;
+  description: string;
+  time: string;
+};
+
+type DashboardSystemStatus = {
+  label: string;
+  state: string;
+  badge: string;
+  description: string;
+};
+
+type DashboardSummaryResponse = {
+  metrics: DashboardMetric[];
+  activity: DashboardActivity[];
+  system_status: DashboardSystemStatus[];
+};
+
+const fetcher = async (url: string): Promise<DashboardSummaryResponse> => {
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error('Failed to load dashboard summary');
+  }
+  return response.json();
+};
+
+function useDashboardSummary() {
+  return useSWR<DashboardSummaryResponse>(`${apiBase}/dashboard/summary`, fetcher, {
+    refreshInterval: 30000,
+    revalidateOnFocus: false,
+  });
+}
+
+export function DashboardMetrics() {
+  const { data, error } = useDashboardSummary();
+  const metrics = data?.metrics ?? [];
+  const isLoading = !data && !error;
+
+  if (error) {
+    return (
+      <div className="col-span-full rounded-2xl border border-rose-500/40 bg-rose-500/10 p-6 text-sm text-rose-100">
+        Unable to load metrics.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={`metric-skeleton-${index}`}
+            className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/20"
+          >
+            <div className="h-3 w-24 rounded-full bg-white/10" />
+            <div className="mt-6 h-8 w-20 rounded-full bg-white/10" />
+            <div className="mt-3 h-3 w-32 rounded-full bg-white/10" />
+            <div className="mt-2 h-3 w-28 rounded-full bg-white/10" />
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {metrics.map((metric) => (
+        <div
+          key={metric.label}
+          className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/20 transition hover:border-white/30 hover:bg-white/10"
+        >
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">{metric.label}</p>
+          <p className="mt-4 text-3xl font-semibold text-white">
+            {typeof metric.value === 'number' ? metric.value.toLocaleString() : metric.value}
+          </p>
+          <p className="mt-2 text-xs font-semibold text-emerald-300">{metric.change}</p>
+          <p className="mt-1 text-xs text-slate-400">{metric.status}</p>
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function DashboardActivityList() {
+  const { data, error } = useDashboardSummary();
+  const activity = data?.activity ?? [];
+  const isLoading = !data && !error;
+
+  if (error) {
+    return (
+      <li className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+        Unable to load recent activity.
+      </li>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <li key={`activity-skeleton-${index}`} className="border-l-2 border-sky-500/20 pl-4">
+            <div className="h-4 w-36 rounded-full bg-white/10" />
+            <div className="mt-2 h-3 w-48 rounded-full bg-white/10" />
+            <div className="mt-3 h-2 w-24 rounded-full bg-white/10" />
+          </li>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {activity.map((item) => (
+        <li key={`${item.title}-${item.time}`} className="border-l-2 border-sky-500/60 pl-4">
+          <p className="text-sm font-semibold text-white">{item.title}</p>
+          <p className="mt-1 text-xs text-slate-300">{item.description}</p>
+          <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">{item.time}</p>
+        </li>
+      ))}
+      {!activity.length && (
+        <li className="text-xs text-slate-400">No recent activity recorded.</li>
+      )}
+    </>
+  );
+}
+
+export function DashboardSystemStatusList() {
+  const { data, error } = useDashboardSummary();
+  const statuses = data?.system_status ?? [];
+  const isLoading = !data && !error;
+
+  if (error) {
+    return (
+      <li className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+        Unable to load system status.
+      </li>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <li key={`status-skeleton-${index}`} className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.05] p-4">
+            <div className="space-y-2">
+              <div className="h-3 w-24 rounded-full bg-white/10" />
+              <div className="h-3 w-40 rounded-full bg-white/10" />
+            </div>
+            <span className="inline-flex h-6 w-20 items-center justify-center rounded-full bg-white/10 text-[10px] uppercase tracking-[0.35em] text-slate-900">
+               
+            </span>
+          </li>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {statuses.map((status) => (
+        <li
+          key={status.label}
+          className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.05] p-4"
+        >
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-white">{status.label}</p>
+            <p className="text-xs text-slate-300">{status.description}</p>
+          </div>
+          <span
+            className={`inline-flex items-center gap-2 rounded-full ${status.badge} px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-900`}
+          >
+            {status.state}
+          </span>
+        </li>
+      ))}
+      {!statuses.length && (
+        <li className="text-xs text-slate-400">No status signals available.</li>
+      )}
+    </>
+  );
+}

--- a/app/web/app/page.tsx
+++ b/app/web/app/page.tsx
@@ -1,31 +1,10 @@
 import Link from 'next/link';
 
-const metrics = [
-  {
-    label: 'Active Orders',
-    value: '248',
-    change: '+18%',
-    status: 'vs last week'
-  },
-  {
-    label: 'Tickets Cleared',
-    value: '182',
-    change: '+12%',
-    status: 'review queue'
-  },
-  {
-    label: 'Inbound Trucks',
-    value: '6',
-    change: '2 arriving',
-    status: 'next 60 min'
-  },
-  {
-    label: 'Label Jobs',
-    value: '34',
-    change: 'ready',
-    status: 'print queue'
-  }
-];
+import {
+  DashboardActivityList,
+  DashboardMetrics,
+  DashboardSystemStatusList
+} from './dashboard-summary-client';
 
 const workspaces = [
   {
@@ -76,45 +55,6 @@ const quickActions = [
   }
 ];
 
-const activityFeed = [
-  {
-    title: 'Inbound truck #542 checked in',
-    description: 'Dock 3 • 12 pallets • ETA 12:40 PM',
-    time: '5 minutes ago'
-  },
-  {
-    title: 'OCR ticket 8319 approved',
-    description: 'Variance resolved by Avery Howard',
-    time: '17 minutes ago'
-  },
-  {
-    title: 'Kiosk sale completed',
-    description: 'Order #004192 ready for invoicing',
-    time: '23 minutes ago'
-  }
-];
-
-const systemStatus = [
-  {
-    label: 'Celery Workers',
-    state: 'Operational',
-    badge: 'bg-emerald-500',
-    description: 'All queues healthy and under threshold.'
-  },
-  {
-    label: 'OCR Pipeline',
-    state: 'Syncing',
-    badge: 'bg-sky-400',
-    description: 'Processing 4 handwritten tickets right now.'
-  },
-  {
-    label: 'Label Service',
-    state: 'Standby',
-    badge: 'bg-amber-400',
-    description: 'Waiting for next scheduled batch at 1:15 PM.'
-  }
-];
-
 export default function HomePage() {
   return (
     <main className="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-16 px-6 py-16 text-slate-100 lg:px-12 lg:py-20">
@@ -144,17 +84,7 @@ export default function HomePage() {
           </div>
         </div>
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {metrics.map((metric) => (
-            <div
-              key={metric.label}
-              className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/20 transition hover:border-white/30 hover:bg-white/10"
-            >
-              <p className="text-xs uppercase tracking-[0.35em] text-slate-400">{metric.label}</p>
-              <p className="mt-4 text-3xl font-semibold text-white">{metric.value}</p>
-              <p className="mt-2 text-xs font-semibold text-emerald-300">{metric.change}</p>
-              <p className="mt-1 text-xs text-slate-400">{metric.status}</p>
-            </div>
-          ))}
+          <DashboardMetrics />
         </div>
       </header>
 
@@ -221,13 +151,7 @@ export default function HomePage() {
               <span className="text-xs uppercase tracking-[0.35em] text-slate-400">Live</span>
             </div>
             <ul className="mt-6 space-y-5">
-              {activityFeed.map((item) => (
-                <li key={item.title} className="border-l-2 border-sky-500/60 pl-4">
-                  <p className="text-sm font-semibold text-white">{item.title}</p>
-                  <p className="mt-1 text-xs text-slate-300">{item.description}</p>
-                  <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">{item.time}</p>
-                </li>
-              ))}
+              <DashboardActivityList />
             </ul>
           </div>
 
@@ -237,17 +161,7 @@ export default function HomePage() {
               <span className="text-xs uppercase tracking-[0.35em] text-slate-400">Health</span>
             </div>
             <ul className="mt-6 space-y-5">
-              {systemStatus.map((status) => (
-                <li key={status.label} className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.05] p-4">
-                  <div className="space-y-1">
-                    <p className="text-sm font-semibold text-white">{status.label}</p>
-                    <p className="text-xs text-slate-300">{status.description}</p>
-                  </div>
-                  <span className={`inline-flex items-center gap-2 rounded-full ${status.badge} px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-900`}>
-                    {status.state}
-                  </span>
-                </li>
-              ))}
+              <DashboardSystemStatusList />
             </ul>
           </div>
         </aside>


### PR DESCRIPTION
## Summary
- add a FastAPI dashboard router that aggregates open sales, draft OCR tickets, inbound purchasing, and worker health signals
- define dashboard response schemas and register the router under `/dashboard/summary`
- replace hard-coded dashboard cards with a client component that fetches live data via SWR and the configured API base URL

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package in app/api/tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e5827769208331a67b8207462fd551