### PR TITLE
Add psycopg2 dependency for Postgres support

### DIFF
--- a/app/infra/docker/api.Dockerfile
+++ b/app/infra/docker/api.Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.11-slim
 
 WORKDIR /workspace
 COPY pyproject.toml poetry.lock* requirements*.txt* ./
-RUN pip install --no-cache-dir fastapi uvicorn[standard] sqlalchemy[asyncio] asyncpg alembic pydantic-settings celery redis boto3 pytesseract pillow httpx
+RUN pip install --no-cache-dir fastapi uvicorn[standard] sqlalchemy[asyncio] asyncpg alembic pydantic-settings celery redis boto3 psycopg2-binary pytesseract pillow httpx
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sqlalchemy[asyncio]
 asyncpg
 aiosqlite
 alembic
+psycopg2-binary
 pydantic-settings
 celery
 redis


### PR DESCRIPTION
## Summary
- add psycopg2-binary to the Python requirements so Postgres connections via psycopg2 are available
- ensure the API Docker image installs psycopg2-binary alongside the other dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5843dcbcc83319b4ca5f991e100bf