### PR TITLE
Fix async database engine to use async driver

### DIFF
--- a/app/api/db.py
+++ b/app/api/db.py
@@ -3,12 +3,30 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from .config import get_settings
 
 settings = get_settings()
-engine = create_async_engine(settings.database_url, echo=False, future=True)
+
+
+def _ensure_async_driver(database_url: str) -> str:
+    """Return a URL that uses an async driver suitable for ``create_async_engine``."""
+
+    url = make_url(database_url)
+    drivername = url.drivername
+
+    dialect, _, driver = drivername.partition("+")
+    if dialect in {"postgresql", "postgres"} and driver != "asyncpg":
+        url = url.set(drivername="postgresql+asyncpg")
+    elif dialect == "sqlite" and driver != "aiosqlite":
+        url = url.set(drivername="sqlite+aiosqlite")
+
+    return str(url)
+
+
+engine = create_async_engine(_ensure_async_driver(settings.database_url), echo=False, future=True)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 

--- a/app/infra/docker/api.Dockerfile
+++ b/app/infra/docker/api.Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.11-slim
 
 WORKDIR /workspace
 COPY pyproject.toml poetry.lock* requirements*.txt* ./
-RUN pip install --no-cache-dir fastapi uvicorn[standard] sqlalchemy[asyncio] asyncpg alembic pydantic-settings celery redis boto3 pytesseract pillow httpx
+RUN pip install --no-cache-dir fastapi uvicorn[standard] sqlalchemy[asyncio] asyncpg alembic pydantic-settings celery redis boto3 psycopg2-binary pytesseract pillow httpx
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sqlalchemy[asyncio]
 asyncpg
 aiosqlite
 alembic
+psycopg2-binary
 pydantic-settings
 celery
 redis


### PR DESCRIPTION
## Summary
- ensure the async SQLAlchemy engine swaps synchronous Postgres URLs to use asyncpg
- normalize sqlite URLs to use the aiosqlite driver when building the async engine

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e5843dcbcc83319b4ca5f991e100bf