### PR TITLE
Allow local settings to default Redis URL

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -105,10 +105,14 @@ class Settings(BaseSettings):
             self.redis_url = f"{scheme}://{auth}{self.redis_host}:{port}/{self.redis_db}"
             return self
 
-        raise ValueError(
-            "Redis connection details are required. Set REDIS_URL/REDIS_TLS_URL "
-            "or the discrete REDIS_* variables so Celery can reach Redis."
-        )
+        if self.environment == "production":
+            raise ValueError(
+                "Redis connection details are required. Set REDIS_URL/REDIS_TLS_URL "
+                "or the discrete REDIS_* variables so Celery can reach Redis."
+            )
+
+        self.redis_url = "redis://localhost:6379/0"
+        return self
 
 @lru_cache(1)
 def get_settings() -> Settings:

--- a/app/api/tests/test_config.py
+++ b/app/api/tests/test_config.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from app.api import config
+
+
+def _clear_settings_cache() -> None:
+    config.get_settings.cache_clear()
+
+
+def _clear_redis_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "REDIS_URL",
+        "REDIS_TLS_URL",
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_USERNAME",
+        "REDIS_PASSWORD",
+        "REDIS_DB",
+        "REDIS_USE_TLS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_get_settings_defaults_to_local_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    _clear_redis_env(monkeypatch)
+    _clear_settings_cache()
+
+    settings = config.get_settings()
+
+    assert settings.redis_url == "redis://localhost:6379/0"
+
+
+def test_get_settings_respects_explicit_redis_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_settings_cache()
+    _clear_redis_env(monkeypatch)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://example.com:6380/2")
+
+    settings = config.get_settings()
+
+    assert settings.redis_url == "redis://example.com:6380/2"
+
+
+def test_get_settings_requires_redis_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_redis_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    _clear_settings_cache()
+
+    with pytest.raises(ValueError):
+        config.get_settings()


### PR DESCRIPTION
## Summary
- default the Redis URL to a localhost instance when discrete Redis settings are absent
- preserve the production-only fail-fast behaviour and cover the scenarios with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58eb2c8f4833189b3892e42f1076d