### PR TITLE
Support barcode lookup when adding sale lines

### DIFF
--- a/app/api/routes/sales.py
+++ b/app/api/routes/sales.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_session
-from ..models.domain import InventoryTxn, Item, Sale, SaleLine
+from ..models.domain import Barcode, InventoryTxn, Item, Sale, SaleLine
 from ..schemas.common import (
     OCRSaleTicketResponse,
     SaleCreateRequest,
@@ -68,6 +68,8 @@ async def add_line(sale_id: int, payload: SaleLineRequest, session: AsyncSession
         item_stmt = item_stmt.where(Item.sku == payload.sku)
     elif payload.short_code:
         item_stmt = item_stmt.where(Item.short_code == payload.short_code)
+    elif payload.barcode:
+        item_stmt = item_stmt.join(Barcode).where(Barcode.barcode == payload.barcode)
     else:
         raise HTTPException(status_code=400, detail="missing_identifier")
     item = await session.scalar(item_stmt)

--- a/app/api/tests/conftest.py
+++ b/app/api/tests/conftest.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+import os
 
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
 from ..config import Settings
 from ..db import get_session

--- a/app/api/tests/test_sales.py
+++ b/app/api/tests/test_sales.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from ..db import SessionLocal, engine
+from ..models.base import Base
+from ..models.domain import Barcode, Item, Location, Sale
+from ..routes.sales import add_line
+from ..schemas.common import SaleLineRequest
+
+
+@pytest.mark.asyncio
+async def test_add_line_with_barcode_lookup() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with SessionLocal() as session:
+        item = Item(
+            sku="SKU-ABC",
+            description="Barcode Item",
+            unit_cost=Decimal("10.00"),
+            price=Decimal("20.00"),
+            short_code="SC123",
+        )
+        barcode = Barcode(barcode="012345678905", item=item)
+        location = Location(name="Showroom", type="retail")
+        sale = Sale(status="draft", created_by="tester", source="manual")
+        session.add_all([item, barcode, location, sale])
+        await session.commit()
+        sale_id = sale.sale_id
+        location_id = location.location_id
+
+    payload = SaleLineRequest(barcode="012345678905", location_id=location_id, qty=2)
+
+    async with SessionLocal() as session:
+        response = await add_line(sale_id, payload, session=session)
+        await session.commit()
+
+    assert "sale_line_id" in response
+
+    async with SessionLocal() as session:
+        sale = await session.get(Sale, sale_id)
+        assert sale is not None
+        assert float(sale.total) == pytest.approx(40.0)


### PR DESCRIPTION
## Summary
- allow the add-line endpoint to resolve items using barcodes when SKU and short code are absent
- provide a default Redis URL in the test suite so FastAPI settings load during tests
- add a regression test confirming barcode-based sale line creation updates totals

## Testing
- `pytest app/api/tests/test_sales.py`


------
https://chatgpt.com/codex/tasks/task_e_68e58eb3bb00833194ead10f292e45f1