### PR TITLE
Add inventory search to PO creation workflow

### DIFF
--- a/app/api/routes/items.py
+++ b/app/api/routes/items.py
@@ -145,6 +145,7 @@ async def search_items(q: str, session: AsyncSession = Depends(get_session)) -> 
             description=item.description,
             price=float(item.price),
             short_code=item.short_code,
+            unit_cost=float(item.unit_cost),
         )
         for item in items
     ]
@@ -161,6 +162,7 @@ async def get_by_short_code(code: str, session: AsyncSession = Depends(get_sessi
         description=item.description,
         price=float(item.price),
         short_code=item.short_code,
+        unit_cost=float(item.unit_cost),
     )
 
 
@@ -183,6 +185,7 @@ async def scan(barcode: str, session: AsyncSession = Depends(get_session)) -> di
             description=item.description,
             price=float(item.price),
             short_code=item.short_code,
+            unit_cost=float(item.unit_cost),
         ),
         "locations": [
             {"location": loc, "qty_on_hand": float(qty)} for loc, qty in inventory
@@ -271,6 +274,7 @@ async def get_item_detail(
             description=item.description,
             price=float(item.price),
             short_code=item.short_code,
+            unit_cost=float(item.unit_cost),
         ),
         total_on_hand=total_on_hand,
         locations=locations,

--- a/app/api/schemas/common.py
+++ b/app/api/schemas/common.py
@@ -28,6 +28,7 @@ class ItemSummary(BaseModel):
     description: str
     price: float
     short_code: str
+    unit_cost: float
 
 
 class CustomerSummary(BaseModel):

--- a/app/api/tests/test_items.py
+++ b/app/api/tests/test_items.py
@@ -67,6 +67,7 @@ async def test_get_item_detail_returns_inventory_and_incoming(client) -> None:
     payload = response.json()
 
     assert payload["item"]["sku"] == "SKU-CLICK"
+    assert payload["item"]["unit_cost"] == pytest.approx(10.0)
     assert payload["total_on_hand"] == pytest.approx(5.0)
     assert len(payload["locations"]) == 1
     location_payload = payload["locations"][0]
@@ -116,7 +117,7 @@ async def test_search_items_supports_short_code(client) -> None:
     assert response.status_code == 200
     payload = response.json()
 
-    assert any(result["sku"] == "SKU-SHORT" for result in payload)
+    assert any(result["sku"] == "SKU-SHORT" and result["unit_cost"] == pytest.approx(40.0) for result in payload)
 
 
 @pytest.mark.asyncio

--- a/app/web/app/receiving/purchase-orders/new/page.tsx
+++ b/app/web/app/receiving/purchase-orders/new/page.tsx
@@ -1,16 +1,43 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import { buildAuthHeaders, getApiBase } from '../../../../lib/api';
+
+interface InventoryItemSummary {
+  item_id: number;
+  sku: string;
+  description: string;
+  price: number;
+  short_code: string;
+  unit_cost: number;
+}
+
+interface PurchaseOrderLine {
+  itemId: number | null;
+  sku: string;
+  description: string;
+  quantity: number;
+  unitCost: number;
+  lastUnitCost: number | null;
+}
 
 interface PurchaseOrder {
   vendor: string;
   expectedDate: string;
   buyer: string;
   notes: string;
-  lines: Array<{ sku: string; description: string; quantity: number }>;
+  lines: PurchaseOrderLine[];
 }
 
-const createBlankLine = () => ({ sku: '', description: '', quantity: 1 });
+const createBlankLine = (): PurchaseOrderLine => ({
+  itemId: null,
+  sku: '',
+  description: '',
+  quantity: 1,
+  unitCost: 0,
+  lastUnitCost: null
+});
 
 const createDefaultPurchaseOrder = (): PurchaseOrder => ({
   vendor: '',
@@ -23,19 +50,64 @@ const createDefaultPurchaseOrder = (): PurchaseOrder => ({
 export default function ReceivingCreatePurchaseOrderPage() {
   const [purchaseOrder, setPurchaseOrder] = useState<PurchaseOrder>(() => createDefaultPurchaseOrder());
   const [confirmation, setConfirmation] = useState<string | null>(null);
+  const api = useMemo(() => getApiBase(), []);
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }),
+    []
+  );
+  const [itemSearch, setItemSearch] = useState('');
+  const [searchResults, setSearchResults] = useState<InventoryItemSummary[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
 
-  const updateLine = (index: number, field: 'sku' | 'description' | 'quantity', value: string) => {
+  const updateLine = (
+    index: number,
+    field: 'sku' | 'description' | 'quantity' | 'unitCost',
+    value: string
+  ) => {
     setPurchaseOrder((state) => ({
       ...state,
       lines: state.lines.map((line, lineIndex) =>
         lineIndex === index
           ? {
               ...line,
-              [field]: field === 'quantity' ? Number(value) || 0 : value
+              [field]: field === 'quantity' || field === 'unitCost' ? Number(value) || 0 : value
             }
           : line
       )
     }));
+  };
+
+  const addInventoryLine = (item: InventoryItemSummary) => {
+    setPurchaseOrder((state) => {
+      const mappedLine: PurchaseOrderLine = {
+        itemId: item.item_id,
+        sku: item.sku,
+        description: item.description,
+        quantity: 1,
+        unitCost: item.unit_cost ?? 0,
+        lastUnitCost: item.unit_cost ?? null
+      };
+
+      const nextLines = [...state.lines];
+      const blankIndex = nextLines.findIndex((line) => !line.itemId && !line.sku);
+      if (blankIndex >= 0) {
+        nextLines[blankIndex] = mappedLine;
+      } else {
+        nextLines.push(mappedLine);
+      }
+
+      return {
+        ...state,
+        lines: nextLines
+      };
+    });
+    setItemSearch('');
+    setSearchResults([]);
+    setSearchError(null);
+    setHasSearched(false);
+    setIsSearching(false);
   };
 
   const addLine = () => {
@@ -51,7 +123,63 @@ export default function ReceivingCreatePurchaseOrderPage() {
       `PO drafted for ${purchaseOrder.vendor || 'unspecified vendor'} with ${purchaseOrder.lines.length} line item(s).`
     );
     setPurchaseOrder(createDefaultPurchaseOrder());
+    setItemSearch('');
+    setSearchResults([]);
+    setSearchError(null);
+    setHasSearched(false);
+    setIsSearching(false);
   };
+
+  useEffect(() => {
+    const trimmed = itemSearch.trim();
+    if (trimmed.length < 2) {
+      setSearchResults([]);
+      setSearchError(null);
+      setIsSearching(false);
+      setHasSearched(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setIsSearching(true);
+
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const headers = await buildAuthHeaders({ Accept: 'application/json' });
+        const response = await fetch(`${api}/items/search?q=${encodeURIComponent(trimmed)}`, {
+          headers,
+          signal: controller.signal
+        });
+        if (!response.ok) {
+          throw new Error('search_failed');
+        }
+        const data = (await response.json()) as InventoryItemSummary[];
+        if (!cancelled) {
+          setSearchResults(data);
+          setSearchError(null);
+          setHasSearched(true);
+        }
+      } catch (error) {
+        if (controller.signal.aborted || cancelled) {
+          return;
+        }
+        setSearchResults([]);
+        setHasSearched(false);
+        setSearchError('Unable to search inventory right now.');
+      } finally {
+        if (!cancelled) {
+          setIsSearching(false);
+        }
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      window.clearTimeout(timeoutId);
+    };
+  }, [api, itemSearch]);
 
   return (
     <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 bg-slate-900 p-8 text-white">
@@ -92,7 +220,7 @@ export default function ReceivingCreatePurchaseOrderPage() {
               className="rounded-lg border border-white/10 bg-slate-900 px-4 py-3 text-white focus:border-sky-400 focus:outline-none"
             />
           </label>
-          <div className="space-y-3">
+          <div className="space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold">Line items</h2>
               <button
@@ -103,9 +231,54 @@ export default function ReceivingCreatePurchaseOrderPage() {
                 Add line
               </button>
             </div>
+            <div className="rounded-2xl border border-white/10 bg-slate-900/80 p-4">
+              <label className="grid gap-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+                <span>Search inventory</span>
+                <input
+                  value={itemSearch}
+                  onChange={(event) => setItemSearch(event.target.value)}
+                  placeholder="Search by SKU, description, or short code"
+                  className="rounded-lg border border-white/10 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-400 focus:outline-none"
+                />
+              </label>
+              {itemSearch.trim().length >= 2 && (
+                <div className="mt-3 divide-y divide-white/5 overflow-hidden rounded-xl border border-white/10 bg-slate-950/70">
+                  {isSearching ? (
+                    <p className="px-4 py-3 text-xs text-slate-300">Searching inventory…</p>
+                  ) : searchError ? (
+                    <p className="px-4 py-3 text-xs text-rose-300">{searchError}</p>
+                  ) : hasSearched && searchResults.length === 0 ? (
+                    <p className="px-4 py-3 text-xs text-slate-300">
+                      No inventory items matched “{itemSearch}”.
+                    </p>
+                  ) : (
+                    <ul className="divide-y divide-white/5 text-sm">
+                      {searchResults.map((item) => (
+                        <li key={item.item_id}>
+                          <button
+                            type="button"
+                            onClick={() => addInventoryLine(item)}
+                            className="flex w-full flex-col gap-1 px-4 py-3 text-left transition hover:bg-sky-500/10 focus:outline-none focus-visible:bg-sky-500/10"
+                          >
+                            <span className="text-sm font-semibold text-slate-100">{item.sku}</span>
+                            <span className="text-xs text-slate-300">{item.description}</span>
+                            <span className="text-[11px] uppercase tracking-[0.2em] text-slate-400">
+                              Last cost {currencyFormatter.format(item.unit_cost)}
+                            </span>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
             <div className="grid gap-4">
               {purchaseOrder.lines.map((line, index) => (
-                <div key={index} className="grid gap-3 rounded-2xl border border-white/10 bg-slate-900/80 p-4 sm:grid-cols-[1fr_2fr_minmax(88px,_120px)] sm:items-center sm:gap-4">
+                <div
+                  key={index}
+                  className="grid gap-3 rounded-2xl border border-white/10 bg-slate-900/80 p-4 sm:grid-cols-[1fr_2fr_minmax(88px,_120px)_minmax(120px,_160px)] sm:items-start sm:gap-4"
+                >
                   <label className="grid gap-1 text-xs uppercase tracking-[0.2em] text-slate-400">
                     <span>SKU</span>
                     <input
@@ -134,6 +307,30 @@ export default function ReceivingCreatePurchaseOrderPage() {
                       className="rounded-lg border border-white/10 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-400 focus:outline-none"
                     />
                   </label>
+                  <label className="grid gap-1 text-xs uppercase tracking-[0.2em] text-slate-400">
+                    <span>Unit cost</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={line.unitCost}
+                      onChange={(event) => updateLine(index, 'unitCost', event.target.value)}
+                      className="rounded-lg border border-white/10 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-400 focus:outline-none"
+                    />
+                  </label>
+                  {line.lastUnitCost !== null && (
+                    <p className="text-[11px] uppercase tracking-[0.2em] text-slate-400 sm:col-span-4">
+                      Last catalog cost{' '}
+                      <span className="font-semibold text-slate-200">
+                        {currencyFormatter.format(line.lastUnitCost)}
+                      </span>
+                      {Math.abs(line.unitCost - line.lastUnitCost) > 0.009 && (
+                        <span className="ml-2 text-amber-300">
+                          Adjusted to {currencyFormatter.format(line.unitCost)}
+                        </span>
+                      )}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- expose item unit costs through the search and item summary endpoints
- enhance the purchase order creation screen with inventory search-driven line entries
- verify unit costs in API tests to cover the new response shape

## Testing
- pytest app/api/tests/test_items.py *(fails: missing pytest_asyncio in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909044e37bc8331af403ce58f90dbb7